### PR TITLE
Add in SSL verification

### DIFF
--- a/theforeman.ini.example
+++ b/theforeman.ini.example
@@ -2,6 +2,9 @@
 #
 
 [theforeman]
-host = https://URL_TO_FOREMAN
+host = forman.domain.tld
 username = username
 password = password
+cacert = /path/to/ssl/cacert (optional)
+cert = /path/to/ssl/cert (optional)
+key = /path/to/ssl/key (optional)


### PR DESCRIPTION
Addresses issue #2.  Allows unverified connection for backwards compatibility.
Optionally a 'cacert' parameter to verfiy server trust.  Also optionally for
really strict configurations you can specify 'cert' and 'key' for client
verification by the server endpoint.