### PR TITLE
Use title instead of name

### DIFF
--- a/theforeman.py
+++ b/theforeman.py
@@ -114,7 +114,7 @@ class TheForemanInventory(object):
         self.inventory = {}
     else:
       for host in data:
-        for hostgroup in self.get_hostgroups(host['hostgroup_name']):
+        for hostgroup in self.get_hostgroups(host['hostgroup_title']):
           self.inventory.setdefault(hostgroup, []).append(host['name'])
         self.inventory['_meta']['hostvars'][host['name']] = host
 


### PR DESCRIPTION
With the most recent version of theforeman it seems like there's been a slight change in the API. Using hostgroup_title enable the use of hierarchical paths as opposed to hostgroup_name